### PR TITLE
Add support to generic ciphered byte encoding.

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -2,7 +2,6 @@ use regex_syntax::hir::{
     visit, Anchor, Class, Hir, HirKind, Literal, RepetitionKind, RepetitionRange, Visitor,
 };
 use regex_syntax::Parser;
-use tfhe_regex::convert_char;
 
 use crate::program::{Action, Instruction, IntervalCharOptions, Program, ProgramItem};
 
@@ -57,7 +56,7 @@ impl Visitor for ProgramFactory {
                     match literal {
                         Literal::Unicode(c) => {
                             self.program.push(ProgramItem {
-                                instruction: Instruction::Char(convert_char(*c as u8)),
+                                instruction: Instruction::Char(*c as u8),
                                 action: Action {
                                     next: self.program.len() + 1 + start,
                                     offset: 1,
@@ -66,7 +65,7 @@ impl Visitor for ProgramFactory {
                         }
                         Literal::Byte(b) => {
                             self.program.push(ProgramItem {
-                                instruction: Instruction::Char(convert_char(*b)),
+                                instruction: Instruction::Char(*b),
                                 action: Action {
                                     next: self.program.len() + 1 + start,
                                     offset: 1,
@@ -125,12 +124,12 @@ impl Visitor for ProgramFactory {
                         HirKind::Literal(literal) => {
                             let (instruction, repetition) = match literal {
                                 Literal::Unicode(c) => (
-                                    Instruction::Char(convert_char(*c as u8)),
-                                    Instruction::Repetition(convert_char(*c as u8)),
+                                    Instruction::Char(*c as u8),
+                                    Instruction::Repetition(*c as u8),
                                 ),
                                 Literal::Byte(b) => (
-                                    Instruction::Char(convert_char(*b)),
-                                    Instruction::Repetition(convert_char(*b)),
+                                    Instruction::Char(*b as u8),
+                                    Instruction::Repetition(*b as u8),
                                 ),
                             };
                             self.program.push(ProgramItem {
@@ -182,9 +181,9 @@ impl Visitor for ProgramFactory {
                         HirKind::Literal(literal) => {
                             let instruction = match literal {
                                 Literal::Unicode(c) => {
-                                    Instruction::Repetition(convert_char(*c as u8))
+                                    Instruction::Repetition(*c as u8)
                                 }
-                                Literal::Byte(b) => Instruction::Repetition(convert_char(*b)),
+                                Literal::Byte(b) => Instruction::Repetition(*b),
                             };
                             self.program.push(ProgramItem {
                                 instruction,
@@ -217,9 +216,9 @@ impl Visitor for ProgramFactory {
                         HirKind::Literal(literal) => {
                             let instruction = match literal {
                                 Literal::Unicode(c) => {
-                                    Instruction::OptionalChar(convert_char(*c as u8))
+                                    Instruction::OptionalChar(*c as u8)
                                 }
-                                Literal::Byte(b) => Instruction::OptionalChar(convert_char(*b)),
+                                Literal::Byte(b) => Instruction::OptionalChar(*b),
                             };
                             self.program.push(ProgramItem {
                                 instruction,
@@ -253,9 +252,9 @@ impl Visitor for ProgramFactory {
                             HirKind::Literal(literal) => {
                                 let instruction = match literal {
                                     Literal::Unicode(c) => {
-                                        Instruction::Char(convert_char(*c as u8))
+                                        Instruction::Char(*c as u8)
                                     }
-                                    Literal::Byte(b) => Instruction::Char(convert_char(*b)),
+                                    Literal::Byte(b) => Instruction::Char(*b),
                                 };
                                 for _i in 0..n {
                                     self.program.push(ProgramItem {
@@ -294,12 +293,12 @@ impl Visitor for ProgramFactory {
                             HirKind::Literal(literal) => {
                                 let (instruction, repetition) = match literal {
                                     Literal::Unicode(c) => (
-                                        Instruction::Char(convert_char(*c as u8)),
-                                        Instruction::Repetition(convert_char(*c as u8)),
+                                        Instruction::Char(*c as u8),
+                                        Instruction::Repetition(*c as u8),
                                     ),
                                     Literal::Byte(b) => (
-                                        Instruction::Char(convert_char(*b)),
-                                        Instruction::Repetition(convert_char(*b)),
+                                        Instruction::Char(*b),
+                                        Instruction::Repetition(*b),
                                     ),
                                 };
                                 for _i in 0..n {
@@ -359,12 +358,12 @@ impl Visitor for ProgramFactory {
                             HirKind::Literal(literal) => {
                                 let (instruction, optional_char) = match literal {
                                     Literal::Unicode(c) => (
-                                        Instruction::Char(convert_char(*c as u8)),
-                                        Instruction::OptionalChar(convert_char(*c as u8)),
+                                        Instruction::Char(*c as u8),
+                                        Instruction::OptionalChar(*c as u8),
                                     ),
                                     Literal::Byte(b) => (
-                                        Instruction::Char(convert_char(*b)),
-                                        Instruction::OptionalChar(convert_char(*b)),
+                                        Instruction::Char(*b),
+                                        Instruction::OptionalChar(*b),
                                     ),
                                 };
                                 for _i in 0..m {

--- a/src/encoded_cipher_tests.rs
+++ b/src/encoded_cipher_tests.rs
@@ -18,8 +18,8 @@ fn get_keys() -> Result<(ClientKey, ServerKey, CheckerCipher), String> {
 
 #[test]
 fn check_encrypt_decrypt() {
-    let (client_key, server_key, _) = get_keys().unwrap();
-    for (value) in [1_u8, 245_u8, 56_u8, 67_u8, 23_u8, 69_u8, 52_u8, 123_u8, 59_u8] {
+    let (client_key, _, _) = get_keys().unwrap();
+    for value in [1_u8, 245_u8, 56_u8, 67_u8, 23_u8, 69_u8, 52_u8, 123_u8, 59_u8] {
         let cipher = TestEncodedCipher::encrypt(&client_key, value);
         let result = cipher.decrypt(&client_key);
         assert!(value == result);

--- a/src/encoded_cipher_tests.rs
+++ b/src/encoded_cipher_tests.rs
@@ -1,0 +1,93 @@
+use crate::CheckerCipher;
+use tfhe::shortint::{parameters::PARAM_MESSAGE_4_CARRY_4, prelude::*};
+use tfhe_regex::{EncodedCipher2bits, EncodedCipher4bits, EncodedCipherTrait};
+
+type TestEncodedCipher = EncodedCipher2bits;
+
+fn ct_is_true(ct_result: &Ciphertext, client_key: &ClientKey) -> bool {
+    client_key.decrypt(ct_result) != 0_u64
+}
+
+fn get_keys() -> Result<(ClientKey, ServerKey, CheckerCipher), String> {
+    let (client_key, server_key) = gen_keys(PARAM_MESSAGE_2_CARRY_2);
+    let checker = CheckerCipher {
+        client_key: client_key.clone(),
+    };
+    Ok((client_key, server_key, checker))
+}
+
+#[test]
+fn check_encrypt_decrypt() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (value) in [1_u8, 245_u8, 56_u8, 67_u8, 23_u8, 69_u8, 52_u8, 123_u8, 59_u8] {
+        let cipher = TestEncodedCipher::encrypt(&client_key, value);
+        let result = cipher.decrypt(&client_key);
+        assert!(value == result);
+    }    
+}
+
+#[test]
+fn check_equal() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(230_u8, 230_u8), (18_u8, 18_u8), (1_u8, 1_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.equal(&server_key, right);
+        assert!(ct_is_true(&result, &client_key))
+    }
+}
+
+#[test]
+fn check_equal_fail() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(30_u8, 21_u8), (18_u8, 28_u8), (1_u8, 0_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.equal(&server_key, right);
+        assert!(!ct_is_true(&result, &client_key))
+    }
+}
+
+#[test]
+fn check_greater_or_equal() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(240_u8, 230_u8), (230_u8, 230_u8), (1_u8, 1_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.greater_or_equal(&server_key, right);
+        assert!(ct_is_true(&result, &client_key))
+    }
+}
+
+#[test]
+fn check_greater_or_equal_fail() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(16_u8, 17_u8), (230_u8, 240_u8), (0_u8, 1_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.greater_or_equal(&server_key, right);
+        assert!(!ct_is_true(&result, &client_key))
+    }
+}
+
+#[test]
+fn check_less_or_equal() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(16_u8, 17_u8), (230_u8, 230_u8), (0_u8, 1_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.less_or_equal(&server_key, right);
+        assert!(ct_is_true(&result, &client_key))
+    }
+}
+
+#[test]
+fn check_less_or_equal_fail() {
+    let (client_key, server_key, _) = get_keys().unwrap();
+    for (left, right) in [(130_u8, 30_u8), (232_u8, 231_u8), (17_u8, 1_u8)] {
+        let left = TestEncodedCipher::encrypt(&client_key, left);
+        let right = TestEncodedCipher::encrypt(&client_key, right);
+        let result = left.less_or_equal(&server_key, right);
+        assert!(!ct_is_true(&result, &client_key))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,10 +103,46 @@ impl EncodedCipherTrait for EncodedCipher2bits {
     }
 
     fn greater_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
-        todo!()
+        // (Ai > Bi) + (Ai == Bi) *
+        //          (Aj > Bj) + (Aj == Bj) *
+        //                  (Ak > Bk) + (Ak == Bk) *
+        //                          (Al >= Bl) 
+        let result_i = server_key.unchecked_greater(&self.i, &rhs.i);
+        let result_i_equal = server_key.unchecked_equal(&self.i, &rhs.i);
+        let result_j = server_key.unchecked_greater(&self.j, &rhs.j);
+        let result_j_equal = server_key.unchecked_equal(&self.j, &rhs.j);
+        let result_k = server_key.unchecked_greater(&self.k, &rhs.k);
+        let result_k_equal = server_key.unchecked_equal(&self.k, &rhs.k);
+        let result_l = server_key.unchecked_greater_or_equal(&self.l, &rhs.l);
+
+        let result = server_key.unchecked_mul_lsb(&result_k_equal, &result_l);
+        let result = server_key.unchecked_add(&result_k, &result);
+        let result = server_key.unchecked_mul_lsb(&result_j_equal, &result);
+        let result = server_key.unchecked_add(&result_j, &result);
+        let result = server_key.smart_scalar_greater_or_equal(&result, 1_u8);
+        let result = server_key.unchecked_mul_lsb(&result_i_equal, &result);
+        server_key.unchecked_add(&result_i, &result)
     }
 
     fn less_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
-        todo!()
+        // (Ai < Bi) + (Ai == Bi) *
+        //          (Aj < Bj) + (Aj == Bj) *
+        //                  (Ak < Bk) + (Ak == Bk) *
+        //                          (Al <= Bl) 
+        let result_i = server_key.unchecked_less(&self.i, &rhs.i);
+        let result_i_equal = server_key.unchecked_equal(&self.i, &rhs.i);
+        let result_j = server_key.unchecked_less(&self.j, &rhs.j);
+        let result_j_equal = server_key.unchecked_equal(&self.j, &rhs.j);
+        let result_k = server_key.unchecked_less(&self.k, &rhs.k);
+        let result_k_equal = server_key.unchecked_equal(&self.k, &rhs.k);
+        let result_l = server_key.unchecked_less_or_equal(&self.l, &rhs.l);
+
+        let result = server_key.unchecked_mul_lsb(&result_k_equal, &result_l);
+        let result = server_key.unchecked_add(&result_k, &result);
+        let result = server_key.unchecked_mul_lsb(&result_j_equal, &result);
+        let result = server_key.unchecked_add(&result_j, &result);
+        let result = server_key.smart_scalar_greater_or_equal(&result, 1_u8);
+        let result = server_key.unchecked_mul_lsb(&result_i_equal, &result);
+        server_key.unchecked_add(&result_i, &result)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,112 @@
-use tfhe::shortint::{Ciphertext, ClientKey};
+use tfhe::shortint::{Ciphertext, ClientKey, ServerKey};
 
-pub fn convert_char(char: u8) -> [u8; 2] {
-    [char & 0x0F, (char >> 4) & 0x0F]
+pub trait EncodedCipherTrait {
+    fn encrypt(client_key: &ClientKey, c: u8) -> Self;
+    fn decrypt(self, client_key: &ClientKey) -> u8;
+
+    fn equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext;
+    fn greater_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext;
+    fn less_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext;
 }
 
-pub fn convert_str_to_cts(input: &str, client_key: &ClientKey) -> Vec<[Ciphertext; 2]> {
+pub fn convert_str_to_cts<T:EncodedCipherTrait>(input: &str, client_key: &ClientKey) -> Vec<T> {
     input
-        .chars()
+    .bytes()
         .map(|c| {
-            let lower = client_key.encrypt((c as u8 & 0x0F) as u64);
-            let upper = client_key.encrypt(((c as u8 >> 4) & 0x0F) as u64);
-            [lower, upper]
+            T::encrypt(client_key, c)
         })
         .collect()
+}
+
+
+#[derive(Clone)]
+pub struct EncodedCipher4bits {
+    upper: Ciphertext,
+    lower: Ciphertext,
+}
+
+impl EncodedCipherTrait for EncodedCipher4bits {
+    fn encrypt(client_key: &ClientKey, c: u8) -> Self {
+        let upper = client_key.encrypt(((c >> 4) & 0x0F) as u64);
+        let lower = client_key.encrypt((c & 0x0F) as u64);
+        EncodedCipher4bits {
+            upper: upper,
+            lower: lower,
+        }
+    }
+
+    fn decrypt(self, client_key: &ClientKey) -> u8 {
+        let upper = client_key.decrypt(&self.upper) as u8;
+        let lower = client_key.decrypt(&self.lower) as u8;
+        ((upper & 0x0F) << 4) | (lower)
+    }
+
+    fn equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        let equal_lower = server_key.unchecked_equal(&self.lower, &rhs.lower);
+        let equal_upper = server_key.unchecked_equal(&self.upper, &rhs.upper);
+        server_key.unchecked_mul_lsb(&equal_lower, &equal_upper)
+    }
+
+    fn greater_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        let result_upper = server_key.unchecked_greater(&self.upper, &rhs.upper);
+        let equal_upper = server_key.unchecked_equal(&self.upper, &rhs.upper);
+        let result_lower = server_key.unchecked_greater_or_equal(&self.lower, &rhs.lower);
+        let result = server_key.unchecked_mul_lsb(&equal_upper, &&result_lower);
+        server_key.unchecked_add(&result_upper, &result)
+    }
+
+    fn less_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        let result_upper = server_key.unchecked_less(&self.upper, &rhs.upper);
+        let equal_upper = server_key.unchecked_equal(&self.upper, &rhs.upper);
+        let result_lower = server_key.unchecked_less_or_equal(&self.lower, &rhs.lower);
+
+        let result = server_key.unchecked_mul_lsb(&equal_upper, &result_lower);
+        server_key.unchecked_add(&result_upper, &result)
+    }
+}
+
+#[derive(Clone)]
+pub struct EncodedCipher2bits {
+    // MSB - LSB
+    // i | j | k | l
+    i: Ciphertext,
+    j: Ciphertext,
+    k: Ciphertext,
+    l: Ciphertext,
+}
+
+impl EncodedCipherTrait for EncodedCipher2bits {
+    fn encrypt(client_key: &ClientKey, c: u8) -> Self {
+        let i = client_key.encrypt(((c >> 6) & 0x03) as u64);
+        let j = client_key.encrypt(((c >> 4) & 0x03) as u64);
+        let k = client_key.encrypt(((c >> 2) & 0x03) as u64);
+        let l = client_key.encrypt((c & 0x3) as u64);
+        EncodedCipher2bits { i: i, j: j, k: k, l: l }
+    }
+
+    fn decrypt(self, client_key: &ClientKey) -> u8 {
+        let i = client_key.decrypt(&self.i) as u8;
+        let j = client_key.decrypt(&self.j) as u8;
+        let k = client_key.decrypt(&self.k) as u8;
+        let l = client_key.decrypt(&self.l) as u8;
+        ((i & 0x03) << 6) | ((j & 0x03) << 4) | ((k & 0x03) << 2) | (l & 0x03)
+    }
+
+    fn equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        let result_i = server_key.unchecked_equal(&self.i, &rhs.i);
+        let result_j = server_key.unchecked_equal(&self.j, &rhs.j);
+        let result_k = server_key.unchecked_equal(&self.k, &rhs.k);
+        let result_l = server_key.unchecked_equal(&self.l, &rhs.l);
+        let result_upper = server_key.unchecked_mul_lsb(&result_i, &result_j);
+        let result_lower = server_key.unchecked_mul_lsb(&result_k, &result_l);
+        server_key.unchecked_mul_lsb(&result_upper, &result_lower)
+    }
+
+    fn greater_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        todo!()
+    }
+
+    fn less_or_equal(self, server_key: &ServerKey, rhs: Self) -> Ciphertext {
+        todo!()
+    }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,5 +1,3 @@
-use tfhe_regex::convert_char;
-
 use crate::program::{Instruction, Program};
 
 #[derive(Default, Clone, Debug)]
@@ -50,7 +48,7 @@ impl Machine {
                     if self.string_counter >= input.len() {
                         return false;
                     }
-                    let input_char = convert_char(input.as_bytes()[self.string_counter]);
+                    let input_char = input.as_bytes()[self.string_counter];
                     let result = input_char == c;
                     if !result {
                         if self.stack.is_empty() {
@@ -94,7 +92,7 @@ impl Machine {
                     exact_match = true;
                 }
                 Instruction::Repetition(c) => {
-                    let input_char = convert_char(input.as_bytes()[self.string_counter]);
+                    let input_char = input.as_bytes()[self.string_counter];
                     let result = input_char == c;
                     if result {
                         self.string_counter =
@@ -105,7 +103,7 @@ impl Machine {
                     }
                 }
                 Instruction::OptionalChar(c) => {
-                    let input_char = convert_char(input.as_bytes()[self.string_counter]);
+                    let input_char = input.as_bytes()[self.string_counter];
                     let result = input_char == c;
                     if result {
                         // if it matches we will go next character of the string

--- a/src/tfhe_machine_tests.rs
+++ b/src/tfhe_machine_tests.rs
@@ -4,9 +4,9 @@ use crate::{
     CheckerCipher,
 };
 use tfhe::shortint::prelude::*;
-use tfhe_regex::{convert_str_to_cts, EncodedCipher4bits};
+use tfhe_regex::{convert_str_to_cts, EncodedCipher2bits, EncodedCipher4bits};
 
-type TestEncodedCipher = EncodedCipher4bits;
+type TestEncodedCipher = EncodedCipher2bits;
 
 
 fn get_keys() -> Result<(ClientKey, ServerKey, CheckerCipher), String> {

--- a/src/tfhe_machine_tests.rs
+++ b/src/tfhe_machine_tests.rs
@@ -4,7 +4,10 @@ use crate::{
     CheckerCipher,
 };
 use tfhe::shortint::prelude::*;
-use tfhe_regex::convert_str_to_cts;
+use tfhe_regex::{convert_str_to_cts, EncodedCipher4bits};
+
+type TestEncodedCipher = EncodedCipher4bits;
+
 
 fn get_keys() -> Result<(ClientKey, ServerKey, CheckerCipher), String> {
     let (client_key, server_key) = gen_keys(Parameters::default());
@@ -18,7 +21,7 @@ fn get_keys() -> Result<(ClientKey, ServerKey, CheckerCipher), String> {
 fn simple_string() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"abc");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("123abc456", &client_key);
 
@@ -31,7 +34,7 @@ fn simple_string() {
 fn simple_string_end_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("123abc", &client_key);
 
@@ -44,7 +47,7 @@ fn simple_string_end_matching_should_succeed() {
 fn simple_string_end_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("123abc456", &client_key);
 
@@ -57,7 +60,7 @@ fn simple_string_end_matching_should_fail() {
 fn simple_string_start_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^abc");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc123", &client_key);
 
@@ -70,7 +73,7 @@ fn simple_string_start_matching_should_succeed() {
 fn simple_string_start_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^abc");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("123abc", &client_key);
 
@@ -83,7 +86,7 @@ fn simple_string_start_matching_should_fail() {
 fn simple_string_exact_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc", &client_key);
 
@@ -96,7 +99,7 @@ fn simple_string_exact_matching_should_succeed() {
 fn simple_string_exact_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("aabc", &client_key);
 
@@ -109,7 +112,7 @@ fn simple_string_exact_matching_should_fail() {
 fn simple_string_exact_matching_should_fail_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abccc", &client_key);
 
@@ -122,7 +125,7 @@ fn simple_string_exact_matching_should_fail_2() {
 fn simple_string_one_or_more_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab+c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbc", &client_key);
 
@@ -135,7 +138,7 @@ fn simple_string_one_or_more_matching_should_succeed() {
 fn simple_string_one_or_more_matching_should_succeed_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab+c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc", &client_key);
 
@@ -148,7 +151,7 @@ fn simple_string_one_or_more_matching_should_succeed_2() {
 fn simple_string_one_or_more_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab+c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("ac", &client_key);
 
@@ -161,7 +164,7 @@ fn simple_string_one_or_more_matching_should_fail() {
 fn simple_string_zero_or_more_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab*c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("ac", &client_key);
 
@@ -174,7 +177,7 @@ fn simple_string_zero_or_more_matching_should_succeed() {
 fn simple_string_zero_or_more_matching_should_succeed_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab*c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbbc", &client_key);
 
@@ -187,7 +190,7 @@ fn simple_string_zero_or_more_matching_should_succeed_2() {
 fn simple_string_optional_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab?c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc", &client_key);
 
@@ -207,7 +210,7 @@ fn simple_string_optional_matching_should_succeed() {
 fn simple_string_optional_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab?c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbc", &client_key);
 
@@ -220,7 +223,7 @@ fn simple_string_optional_matching_should_fail() {
 fn simple_string_numbered_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{2}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbc", &client_key);
 
@@ -233,7 +236,7 @@ fn simple_string_numbered_matching_should_succeed() {
 fn simple_string_numbered_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{2}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbbc", &client_key);
 
@@ -253,7 +256,7 @@ fn simple_string_numbered_matching_should_fail() {
 fn simple_string_numbered_matching_should_succeed_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{3,}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbbc", &client_key);
 
@@ -273,7 +276,7 @@ fn simple_string_numbered_matching_should_succeed_2() {
 fn simple_string_numbered_matching_should_fail_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{3,}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbc", &client_key);
 
@@ -286,7 +289,7 @@ fn simple_string_numbered_matching_should_fail_2() {
 fn simple_string_numbered_matching_should_succeed_3() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{2,4}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abbbbc", &client_key);
 
@@ -299,7 +302,7 @@ fn simple_string_numbered_matching_should_succeed_3() {
 fn simple_string_numbered_matching_should_fail_3() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^ab{2,4}c$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc", &client_key);
 
@@ -319,7 +322,7 @@ fn simple_string_numbered_matching_should_fail_3() {
 fn escaping_special_characters_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^\.$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts(".", &client_key);
 
@@ -332,7 +335,7 @@ fn escaping_special_characters_should_succeed() {
 fn escaping_special_characters_should_succeed_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^\*$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("*", &client_key);
 
@@ -345,7 +348,7 @@ fn escaping_special_characters_should_succeed_2() {
 fn character_range_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^[abc]$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("a", &client_key);
 
@@ -361,7 +364,7 @@ fn character_range_matching_should_fail() {
     // assert!(!machine.run("d".to_string()));
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^[abc]$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("d", &client_key);
 
@@ -374,7 +377,7 @@ fn character_range_matching_should_fail() {
 fn character_range_not_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^[^ade]$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("b", &client_key);
 
@@ -387,7 +390,7 @@ fn character_range_not_matching_should_succeed() {
 fn character_range_not_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^[^ade]$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("a", &client_key);
 
@@ -400,7 +403,7 @@ fn character_range_not_matching_should_fail() {
 fn any_character_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^.$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("A", &client_key);
 
@@ -413,7 +416,7 @@ fn any_character_matching_should_succeed() {
 fn case_insensitive_argument_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"(?i)^abc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("ABC", &client_key);
 
@@ -426,7 +429,7 @@ fn case_insensitive_argument_should_succeed() {
 fn alternation_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"0a|bcd$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("0a", &client_key);
 
@@ -446,7 +449,7 @@ fn alternation_should_succeed() {
 fn alternation_should_succeed_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"a(bc|ed)42$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abc42", &client_key);
 
@@ -466,7 +469,7 @@ fn alternation_should_succeed_2() {
 fn alternation_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"0a|bcd$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("0b", &client_key);
 
@@ -486,7 +489,7 @@ fn alternation_should_fail() {
 fn alternation_should_fail_2() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"a(bc|ed)42$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("abd42", &client_key);
 
@@ -506,7 +509,7 @@ fn alternation_should_fail_2() {
 fn alternation_string_numbered_matching_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^hel(ab{2}|l{3,}o)bc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("helabbbc", &client_key);
 
@@ -526,7 +529,7 @@ fn alternation_string_numbered_matching_should_succeed() {
 fn alternation_string_numbered_matching_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^hel(ab{2}|l{3,}o)bc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("helabbc", &client_key);
 
@@ -547,7 +550,7 @@ fn repetition_with_range_should_succeed() {
     let (client_key, server_key, checker) = get_keys().unwrap();
 
     let program = compiler::Compiler::compile(r"^01[b-e]{4}56$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("01bbbb56", &client_key);
 
@@ -567,7 +570,7 @@ fn repetition_with_range_should_succeed() {
 fn repetition_with_range_should_fail() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^01[b-e]{4}56$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("01bb56", &client_key);
 
@@ -587,7 +590,7 @@ fn repetition_with_range_should_fail() {
 fn repetition_with_range_should_succeed_1() {
     let (client_key, server_key, checker) = get_keys().unwrap();
     let program = compiler::Compiler::compile(r"^hel(a[b-e]{2}|[l-n]{3,}o)bc$");
-    let program = program::cipher_program(&client_key, program);
+    let program = program::cipher_program::<TestEncodedCipher>(&client_key, program);
 
     let input = convert_str_to_cts("helacdbc", &client_key);
 


### PR DESCRIPTION
This PR introduce `EncodedCipherTrait` which allow to easily extend how a ciphered byte is encoded.

The following 'encoded cipher' are available:
- `EncodedCipher4bits`: a ciphered byte is encoded with **4bits** `Ciphertext`
- `EncodedCipher2bits`: a ciphered byte is encoded with **2bits** `Ciphertext`

To reduce running time, tests are setup to use `EncodedCipher2bits` 